### PR TITLE
fix(INJI-612): fix base64 decode/encode for ciphertext+IV

### DIFF
--- a/android/src/main/java/com/reactnativesecurekeystore/CipherBoxImpl.kt
+++ b/android/src/main/java/com/reactnativesecurekeystore/CipherBoxImpl.kt
@@ -29,8 +29,7 @@ class CipherBoxImpl : CipherBox {
   }
 
   override fun encryptData(cipher: Cipher, data: String): EncryptedOutput {
-    Log.d("CipherBox", "iv ${cipher.iv} data: $data" )
-    val encryptedData = cipher.doFinal(data.toByteArray())
+    val encryptedData = cipher.doFinal(data.toByteArray(), 0, data.toByteArray().size)
 
     return EncryptedOutput(encryptedData, cipher.iv)
   }
@@ -46,7 +45,7 @@ class CipherBoxImpl : CipherBox {
 
   override fun decryptData(cipher: Cipher, encryptedOutput: EncryptedOutput): ByteArray {
     try {
-      return cipher.doFinal(encryptedOutput.encryptedData)
+      return cipher.doFinal(encryptedOutput.encryptedData, 0, encryptedOutput.encryptedData.size)
     } catch (e: Exception) {
       Log.e("Secure","Exception in Decryption",e)
       throw e

--- a/android/src/main/java/com/reactnativesecurekeystore/dto/EncryptedOutput.kt
+++ b/android/src/main/java/com/reactnativesecurekeystore/dto/EncryptedOutput.kt
@@ -14,14 +14,13 @@ class EncryptedOutput {
   }
 
   constructor(encryptedOutput: String) {
-    val ivString = encryptedOutput.take(IV_SIZE)
-    val encryptedString = encryptedOutput.drop(IV_SIZE)
-    this.iv = Base64.decode(ivString, Base64.DEFAULT)
-    this.encryptedData = Base64.decode(encryptedString, Base64.DEFAULT)
+    val cipherText = Base64.decode(encryptedOutput, Base64.DEFAULT)
+    this.iv = cipherText.take(IV_SIZE).toByteArray()
+    this.encryptedData = cipherText.drop(IV_SIZE).toByteArray()
   }
 
   override fun toString(): String {
-    return Base64.encodeToString(iv, Base64.DEFAULT) + Base64.encodeToString(encryptedData, Base64.DEFAULT)
+    return Base64.encodeToString(iv.plus(encryptedData), Base64.DEFAULT)
   }
 
   companion object {

--- a/android/src/main/java/com/reactnativesecurekeystore/dto/EncryptedOutput.kt
+++ b/android/src/main/java/com/reactnativesecurekeystore/dto/EncryptedOutput.kt
@@ -2,7 +2,7 @@ package com.reactnativesecurekeystore.dto
 
 import android.util.Base64
 
-const val IV_SIZE = 16
+const val IV_SIZE = 12
 
 class EncryptedOutput {
   var iv: ByteArray


### PR DESCRIPTION
- the encryptedbytes should be encoded & decoded together to get all the bytes of the IV correctly

# Why is this change required ?

- during encryption we were getting `IV_BYTES` bytes of IV
- during decryption the code was getting `IV_BYTES - 3` bytes of IV
- NOTE: The `IV_BYTES` should be 12 as per recommended best practices and it'll be changed as part of another PR.
- this is **not** a device specific issue

Error observed while decryption in a physical phone(sample phone: Redmi 6A)
```
Unsupported IV length: 9 bytes. Only 12 bytes long IV supported
```

# User visible change

- The Android phone should have crashed on the first data decryption depending upon the IV(aka nonce) generated pseudorandomly by the hardware. This fix decodes & encodes the `EncryptedOutput` string/object correctly. This change ensures that the IV is always IV_BYTES long.