### PR TITLE
[INJIMOB-531] receive base64 encoded string to avoid data truncation

### DIFF
--- a/android/src/main/java/com/reactnativesecurekeystore/CipherBoxImpl.kt
+++ b/android/src/main/java/com/reactnativesecurekeystore/CipherBoxImpl.kt
@@ -29,7 +29,8 @@ class CipherBoxImpl : CipherBox {
   }
 
   override fun encryptData(cipher: Cipher, data: String): EncryptedOutput {
-    val encryptedData = cipher.doFinal(data.toByteArray(), 0, data.toByteArray().size)
+    val decodedData = Base64.decode(data, Base64.DEFAULT)
+    val encryptedData = cipher.doFinal(decodedData, 0, decodedData.size)
 
     return EncryptedOutput(encryptedData, cipher.iv)
   }


### PR DESCRIPTION
When we pass data from a react native app with <part1>\x00<part2> value, any data post the \x00 gets truncated (i.e., part2 is trimmed off). This happens most likely with the react native bridge. To avoid this issue of truncation, we are required to pass the data as base64 encoded string and secure-keystore module will perform decoding before processing for encryption.