### PR TITLE
update workflows to use tagged version of kattu and skip sonar job

### DIFF
--- a/.github/workflows/android-artifact-build.yml
+++ b/.github/workflows/android-artifact-build.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   publish-snapshot:
     if: ${{ inputs.release_type == 'snapshot' }}
-    uses: mosip/kattu/.github/workflows/maven-publish-android.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/maven-publish-android.yml@v0.0.1
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'android'
@@ -53,7 +53,7 @@ jobs:
   
   publish-release:
     if: ${{ inputs.release_type == 'release' }}
-    uses: mosip/kattu/.github/workflows/maven-publish-android-download.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/maven-publish-android-download.yml@v0.0.1
     with:
       SERVICE_LOCATION: 'kotlin'
       ANDROID_SERVICE_LOCATION: 'android'

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -21,20 +21,20 @@ on:
       - MOSIP*
 jobs:
   build-kotlin:
-    uses: mosip/kattu/.github/workflows/gradle-build.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/gradle-build.yml@v0.0.1
     with:
       SERVICE_LOCATION: kotlin/android
       JAVA_VERSION: 17
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
 
-  sonar-analysis-kotlin:
-    needs: build-kotlin
-    if: "${{  github.event_name != 'pull_request' }}"
-    uses: Mahesh-Binayak/kattu/.github/workflows/gradlew-sonar-analysis.yml@sonartest
-    with:
-      SERVICE_LOCATION: kotlin/android
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      ORG_KEY: ${{ secrets.ORG_KEY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
+#  sonar-analysis-kotlin:
+#    needs: build-kotlin
+#    if: "${{  github.event_name != 'pull_request' }}"
+#    uses: Mahesh-Binayak/kattu/.github/workflows/gradlew-sonar-analysis.yml@sonartest
+#    with:
+#      SERVICE_LOCATION: kotlin/android
+#    secrets:
+#      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#      ORG_KEY: ${{ secrets.ORG_KEY }}
+#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   tag-branch:
-    uses: mosip/kattu/.github/workflows/tag.yml@gpgupdate-masterj21
+    uses: mosip/kattu/.github/workflows/tag.yaml@v0.0.1
     with:
       TAG: ${{ inputs.TAG }}
       BODY: ${{ inputs.BODY }}


### PR DESCRIPTION
update kattu tag and commented sonar job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android publishing workflows to use the stable Kattu Maven publishing release.
  * Updated the Kotlin build workflow to use the stable Kattu release.
  * Disabled the Kotlin Sonar analysis job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->