### PR TITLE
fix: add missing signing config to android publish artifact

### DIFF
--- a/kotlin/android/build.gradle
+++ b/kotlin/android/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.sonarqube'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 buildscript {
   ext.kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['SecureKeystore_kotlinVersion']

--- a/kotlin/android/publish-artifact.gradle
+++ b/kotlin/android/publish-artifact.gradle
@@ -109,3 +109,7 @@ publishing {
     }
   }
 }
+signing {
+  useGpgCmd()
+  sign publishing.publications.aar
+}


### PR DESCRIPTION
The `signing` block is missing on `release-1.0.x`. Adds it back, matching `master` and the other library repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Added GPG signing for Android library artifacts to improve publication authenticity and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->